### PR TITLE
Fixing leakage of http socket

### DIFF
--- a/api.go
+++ b/api.go
@@ -369,6 +369,7 @@ func readFileFromRequest(r *http.Request, boundary string) (string, error) {
 	// multipart as this is how the Chef API is designed
 	fp := form.File["tarball"][0]
 	file, err := fp.Open()
+        defer file.Close()
 	if err != nil {
 		return "", err
 	}

--- a/api.go
+++ b/api.go
@@ -539,11 +539,11 @@ func responseBody(resp *http.Response) ([]byte, error) {
 		return nil, errors.New(resp.Status)
 	}
 
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
 
 	return body, nil
 }

--- a/api.go
+++ b/api.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 	"mime"
 	"mime/multipart"
+        "net"
 	"net/http"
 	"net/url"
 	"os"

--- a/api.go
+++ b/api.go
@@ -548,6 +548,7 @@ func responseBody(resp *http.Response) ([]byte, error) {
 		return nil, errors.New(resp.Status)
 	}
 
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -312,6 +312,7 @@ func (chef *Chef) makeRequest(request *http.Request) (*http.Response, error) {
 			TLSHandshakeTimeout: 5 * time.Second,
 			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			DisableKeepAlives: true,
 		}
 		client = &http.Client{
 			Timeout: time.Second * 10,

--- a/api.go
+++ b/api.go
@@ -377,11 +377,11 @@ func readFileFromRequest(r *http.Request, boundary string) (string, error) {
 	// multipart as this is how the Chef API is designed
 	fp := form.File["tarball"][0]
 	file, err := fp.Open()
+	defer file.Close()
 	if err != nil {
 		return "", err
 	}
 	buf, err := ioutil.ReadAll(file)
-	file.Close()
 	if err != nil {
 		return "", err
 	}

--- a/api.go
+++ b/api.go
@@ -377,11 +377,11 @@ func readFileFromRequest(r *http.Request, boundary string) (string, error) {
 	// multipart as this is how the Chef API is designed
 	fp := form.File["tarball"][0]
 	file, err := fp.Open()
-        defer file.Close()
 	if err != nil {
 		return "", err
 	}
 	buf, err := ioutil.ReadAll(file)
+	file.Close()
 	if err != nil {
 		return "", err
 	}
@@ -547,8 +547,8 @@ func responseBody(resp *http.Response) ([]byte, error) {
 		return nil, errors.New(resp.Status)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -543,8 +543,6 @@ func (chef *Chef) apiRequestHeaders(request *http.Request) error {
 
 // Given an http response object, responseBody returns the response body
 func responseBody(resp *http.Response) ([]byte, error) {
-	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New(resp.Status)
 	}

--- a/api.go
+++ b/api.go
@@ -543,12 +543,14 @@ func (chef *Chef) apiRequestHeaders(request *http.Request) error {
 
 // Given an http response object, responseBody returns the response body
 func responseBody(resp *http.Response) ([]byte, error) {
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New(resp.Status)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
+
 	if err != nil {
 		return nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -305,16 +305,16 @@ func (chef *Chef) makeRequest(request *http.Request) (*http.Response, error) {
 	var client *http.Client
 	if chef.SSLNoVerify {
 		tr := &http.Transport{
-                        Dial: (&net.Dialer{
-                        Timeout: 5 * time.Second,
-                        }).Dial,
-                        TLSHandshakeTimeout: 5 * time.Second,
+			Dial: (&net.Dialer{
+				Timeout: 5 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 5 * time.Second,
 			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		client = &http.Client{
-                    Timeout: time.Second * 10,
-                    Transport: tr
+			Timeout: time.Second * 10,
+			Transport: tr,
                 }
 	} else {
 		client = &http.Client{}

--- a/api.go
+++ b/api.go
@@ -305,10 +305,17 @@ func (chef *Chef) makeRequest(request *http.Request) (*http.Response, error) {
 	var client *http.Client
 	if chef.SSLNoVerify {
 		tr := &http.Transport{
+                        Dial: (&net.Dialer{
+                        Timeout: 5 * time.Second,
+                        }).Dial,
+                        TLSHandshakeTimeout: 5 * time.Second,
 			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
-		client = &http.Client{Transport: tr}
+		client = &http.Client{
+                    Timeout: time.Second * 10,
+                    Transport: tr
+                }
 	} else {
 		client = &http.Client{}
 	}

--- a/data.go
+++ b/data.go
@@ -114,12 +114,12 @@ func (chef *Chef) GetTypedDataByName(data interface{}, name string) (bool, error
 		return false, err
 	}
 
-        log.Printf("Before resposneBody")
+        log.Printf("Before unmarshal")
 	if err = json.Unmarshal(body, &data); err != nil {
-                log.Printf("Error on resposneBody")
+                log.Printf("Error on unmarshal")
 		return false, err
 	}
-        log.Printf("After resposneBody")
+        log.Printf("After unmarshal")
 
 	return true, nil
 }

--- a/data.go
+++ b/data.go
@@ -102,6 +102,7 @@ func (chef *Chef) GetDataByName(name string) (map[string]string, bool, error) {
 func (chef *Chef) GetTypedDataByName(data interface{}, name string) (bool, error) {
 	log.Printf("Before chef.Get")
         resp, err := chef.Get(fmt.Sprintf("data/%s", name))
+	defer resp.Body.Close()
         log.Printf("After chef.Get")
 	if err != nil {
 		return false, err

--- a/data.go
+++ b/data.go
@@ -102,11 +102,12 @@ func (chef *Chef) GetDataByName(name string) (map[string]string, bool, error) {
 func (chef *Chef) GetTypedDataByName(data interface{}, name string) (bool, error) {
 	log.Printf("Before chef.Get")
         resp, err := chef.Get(fmt.Sprintf("data/%s", name))
-	defer resp.Body.Close()
         log.Printf("After chef.Get")
 	if err != nil {
 		return false, err
 	}
+	defer resp.Body.Close()
+
         log.Printf("Before resposneBody")
 	body, err := responseBody(resp)
         log.Printf("After resposneBody")

--- a/data.go
+++ b/data.go
@@ -100,7 +100,9 @@ func (chef *Chef) GetDataByName(name string) (map[string]string, bool, error) {
 //        fmt.Printf("%#v", cfg)
 //    }
 func (chef *Chef) GetTypedDataByName(data interface{}, name string) (bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("data/%s", name))
+	log.Printf("Before chef.Get")
+        resp, err := chef.Get(fmt.Sprintf("data/%s", name))
+        log.Printf("After chef.Get")
 	if err != nil {
 		return false, err
 	}

--- a/data.go
+++ b/data.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-        "log"
 )
 
 // chef.GetData returns a map of databag names to their related REST URL
@@ -100,17 +99,12 @@ func (chef *Chef) GetDataByName(name string) (map[string]string, bool, error) {
 //        fmt.Printf("%#v", cfg)
 //    }
 func (chef *Chef) GetTypedDataByName(data interface{}, name string) (bool, error) {
-	log.Printf("Before chef.Get")
         resp, err := chef.Get(fmt.Sprintf("data/%s", name))
-        log.Printf("After chef.Get")
 	if err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
 
-        log.Printf("Before resposneBody")
 	body, err := responseBody(resp)
-        log.Printf("After resposneBody")
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -118,12 +112,9 @@ func (chef *Chef) GetTypedDataByName(data interface{}, name string) (bool, error
 		return false, err
 	}
 
-        log.Printf("Before unmarshal")
 	if err = json.Unmarshal(body, &data); err != nil {
-                log.Printf("Error on unmarshal")
 		return false, err
 	}
-        log.Printf("After unmarshal")
 
 	return true, nil
 }

--- a/data.go
+++ b/data.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+        "log"
 )
 
 // chef.GetData returns a map of databag names to their related REST URL
@@ -103,7 +104,9 @@ func (chef *Chef) GetTypedDataByName(data interface{}, name string) (bool, error
 	if err != nil {
 		return false, err
 	}
+        log.Printf("Before resposneBody")
 	body, err := responseBody(resp)
+        log.Printf("After resposneBody")
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -111,9 +114,12 @@ func (chef *Chef) GetTypedDataByName(data interface{}, name string) (bool, error
 		return false, err
 	}
 
+        log.Printf("Before resposneBody")
 	if err = json.Unmarshal(body, &data); err != nil {
+                log.Printf("Error on resposneBody")
 		return false, err
 	}
+        log.Printf("After resposneBody")
 
 	return true, nil
 }


### PR DESCRIPTION
blocks the next story - https://www.pivotaltracker.com/story/show/146734831

Change improves networking:
- no keep alive sockets as we do not reuse client, helps with HTTP 1.1 servers [main fix]
- set 5, 10 second timeouts on communications with chef server; shall I bump this to 15 seconds?
- close response Body to prevent file leakage 
